### PR TITLE
FreeBSD support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,6 @@ install-data-hook:
 dist_man_MANS = doc/openfortivpn.1
 
 doc/openfortivpn.1: $(srcdir)/doc/openfortivpn.1.in
-	sed -e 's|[@]SYSCONFDIR[@]|$(sysconfdir)|g;s|[@]DATADIR[@]|$(datadir)|g;' $^ >$@
+	sed -e 's|[@]SYSCONFDIR[@]|$(sysconfdir)|g;s|[@]DATADIR[@]|$(datadir)|g;' $(srcdir)/doc/openfortivpn.1.in >$@
 
 EXTRA_DIST = LICENSE README.md doc/openfortivpn.1.in $(data_DATA)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For other distros, you'll need to build and install from source:
     * Gentoo Linux: `net-dialup/ppp` `pkg-config`
     * openSUSE: `gcc` `automake` `autoconf` `libopenssl-devel` `pkg-config`
     * macOS(Homebrew): `automake` `autoconf` `openssl@1.0` `pkg-config`
+    * FreeBSD: `automake` `autoconf` `libressl` `pkgconf`
 
     On Linux, if you manage your kernel yourself, ensure to compile those modules:
     ```

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthr
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h mach/mach.h netdb.h net/if.h netinet/in.h netinet/tcp.h net/route.h pty.h semaphore.h signal.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h syslog.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h unistd.h util.h])
+AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h mach/mach.h netdb.h net/if.h net/if_var.h netinet/in.h netinet/tcp.h net/route.h pty.h semaphore.h signal.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h sys/mutex.h syslog.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h unistd.h util.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthr
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h mach/mach.h netdb.h net/if.h net/if_var.h netinet/in.h netinet/tcp.h net/route.h pty.h semaphore.h signal.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h sys/mutex.h syslog.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h unistd.h util.h])
+AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h libutil.h limits.h mach/mach.h netdb.h net/if.h net/if_var.h netinet/in.h netinet/tcp.h net/route.h pty.h semaphore.h signal.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h sys/mutex.h syslog.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h unistd.h util.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
@@ -70,6 +70,9 @@ int main() {
 AC_CHECK_FILE(/proc/net/route,[AC_DEFINE(HAVE_PROC_NET_ROUTE)],[])
 AC_CHECK_FILE(/usr/sbin/netstat,[AC_DEFINE(HAVE_USR_SBIN_NETSTAT)],[])
 AC_CHECK_FILE(/usr/bin/netstat,[AC_DEFINE(HAVE_USR_BIN_NETSTAT)],[])
+# not yet used, but FreeBSD does not use pppd anymore but user space ppp application
+AC_CHECK_FILE(/usr/sbin/pppd,[AC_DEFINE(HAVE_USR_SBIN_PPPD)],[])
+AC_CHECK_FILE(/usr/sbin/ppp,[AC_DEFINE(HAVE_USR_SBIN_PPP)],[])
 
 
 AC_OUTPUT(Makefile)

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_TYPE_SSIZE_T
 AC_TYPE_UINT16_T
 AC_TYPE_UINT32_T
 AC_TYPE_UINT8_T
+AC_CHECK_TYPES([struct termios], [], [], [#include <termios.h>])
 
 # Checks for library functions.
 AC_FUNC_MALLOC

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,13 @@ AC_CHECK_TYPES([struct termios], [], [], [#include <termios.h>])
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([atoi close connect execv exit _exit fclose fcntl fflush fopen forkpty fprintf fputs free freeaddrinfo freeifaddrs freopen fwrite getaddrinfo getchar getenv getopt_long htons index inet_addr inet_ntoa isatty malloc memcpy memmem memmove memset ntohs open openlog pclose popen printf pthread_cancel pthread_cond_init pthread_cond_signal pthread_cond_wait pthread_join pthread_mutexattr_init pthread_mutex_destroy pthread_mutex_init pthread_mutex_lock pthread_mutex_unlock pthread_sigmask puts read realloc rewind select setenv sigaddset sigemptyset signal snprintf socket sprintf strcasestr strcat strchr strcmp strcpy strdup strerror strlen strncasecmp strncat strncpy strsignal strstr strtok strtok_r strtol syslog system tcsetattr usleep vprintf vsnprintf vsyslog write], [], AC_MSG_ERROR([Required function not present]))
+
+# check for optional functions
 AC_CHECK_FUNCS([pthread_mutexattr_setrobust X509_check_host])
+
+# existence of specific files
+# this does not allow cross platform compiling, but it avoids many #ifdef __OS_TYPE__
+AC_CHECK_FILE(/proc/net/route,[AC_DEFINE(HAVE_PROC_NET_ROUTE)],[])
+
 
 AC_OUTPUT(Makefile)

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,8 @@ PKG_PROG_PKG_CONFIG
 # Helps support multiarch by setting 'host_os' and 'host_cpu'
 AC_CANONICAL_HOST
 
-AM_SILENT_RULES([yes])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
 
 # Checks for libraries.
 PKG_CHECK_MODULES(OPENSSL, [libcrypto libssl])

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,8 @@ AC_CHECK_FUNCS([pthread_mutexattr_setrobust X509_check_host])
 # existence of specific files
 # this does not allow cross platform compiling, but it avoids many #ifdef __OS_TYPE__
 AC_CHECK_FILE(/proc/net/route,[AC_DEFINE(HAVE_PROC_NET_ROUTE)],[])
+AC_CHECK_FILE(/usr/sbin/netstat,[AC_DEFINE(HAVE_USR_SBIN_NETSTAT)],[])
+AC_CHECK_FILE(/usr/bin/netstat,[AC_DEFINE(HAVE_USR_BIN_NETSTAT)],[])
 
 
 AC_OUTPUT(Makefile)

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,26 @@ AC_CHECK_FUNCS([atoi close connect execv exit _exit fclose fcntl fflush fopen fo
 # check for optional functions
 AC_CHECK_FUNCS([pthread_mutexattr_setrobust X509_check_host])
 
+# specialised checks for particular features
+
+AC_MSG_CHECKING(whether rtentry is available and has rt_dst )
+AC_TRY_RUN([
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <net/route.h>
+static inline struct sockaddr_in *cast_addr(struct sockaddr *addr)
+{
+       return (struct sockaddr_in *) addr;
+}
+struct rtentry route;
+int main() {
+  cast_addr(&(&route)->rt_dst)->sin_family = AF_INET;
+  return (cast_addr(&(&route)->rt_dst)->sin_family == AF_INET) ? 0 : 1; }
+], [
+  AC_DEFINE(HAVE_RT_ENTRY_WITH_RT_DST)
+  AC_MSG_RESULT(yes)
+], AC_MSG_RESULT(no) )
+
 # existence of specific files
 # this does not allow cross platform compiling, but it avoids many #ifdef __OS_TYPE__
 AC_CHECK_FILE(/proc/net/route,[AC_DEFINE(HAVE_PROC_NET_ROUTE)],[])

--- a/src/io.c
+++ b/src/io.c
@@ -39,11 +39,11 @@
 #include <string.h>
 #include <errno.h>
 
-#ifdef __APPLE__
-
-/* Mac OS X defines sem_init but actually does not implement them */
+#ifdef HAVE_MACH_MACH_H
+/* this is typical for mach kernel used on Mac OSX */
 #include <mach/mach.h>
 
+/* Mac OS X defines sem_init but actually does not implement them */
 typedef semaphore_t os_semaphore_t;
 
 #define SEM_INIT(sem, x, value)	semaphore_create(mach_task_self(), sem, \

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <errno.h>
+#include <limits.h>
 
 #define SHOW_ROUTE_BUFFER_SIZE 128
 
@@ -313,7 +314,7 @@ static int ipv4_get_route(struct rtentry *route)
 		window = strtol(strtok_r(NULL, "\t", &saveptr2), NULL, 16);
 		irtt = strtol(strtok_r(NULL, "\t", &saveptr2), NULL, 16);
 #else
-                /* parse netstat output on Mac OSX and BSD */
+		/* parse netstat output on Mac OSX and BSD */
 		char tmp_ip_string[16];
 		struct in_addr dstaddr;
 		int pos;
@@ -488,7 +489,7 @@ end:
 static int ipv4_set_route(struct rtentry *route)
 {
 #ifdef HAVE_RT_ENTRY_WITH_RT_DST
-       /* we can copy rtentry struct directly between openfortivpn and kernel */
+	/* we can copy rtentry struct directly between openfortivpn and kernel */
 	log_debug("ip route add %s\n", ipv4_show_route(route));
 
 	int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
@@ -529,7 +530,7 @@ static int ipv4_set_route(struct rtentry *route)
 static int ipv4_del_route(struct rtentry *route)
 {
 #ifdef HAVE_RT_ENTRY_WITH_RT_DST
-       /* we can copy rtentry struct directly between openfortivpn and kernel */
+	/* we can copy rtentry struct directly between openfortivpn and kernel */
 	struct rtentry tmp;
 	int sockfd;
 

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -156,7 +156,14 @@ static int ipv4_get_route(struct rtentry *route)
 	char *saveptr3 = NULL;
 
 	// Open the command for reading
+#ifdef HAVE_USR_SBIN_NETSTAT
+	/* this is the path on Mac OSX */
 	fp = popen("/usr/sbin/netstat -f inet -rn", "r");
+#endif
+#ifdef HAVE_USR_BIN_NETSTAT
+	/* this is for BSD, output however is quite similar */
+	fp = popen("/usr/bin/netstat -f inet -rn", "r");
+#endif
 	if (fp == NULL)
 		return ERR_IPV4_SEE_ERRNO;
 
@@ -271,7 +278,7 @@ static int ipv4_get_route(struct rtentry *route)
 	}
 	start++;
 
-#ifdef __APPLE__
+#ifdef HAVE_USR_SBIN_NETSTAT
 	// Skip 3 more lines on Mac OSX
 	start = index(start, '\n');
 	start = index(++start, '\n');

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -32,7 +32,13 @@
 #include <net/if_var.h>
 #endif
 
-#ifdef __APPLE__
+#ifndef HAVE_RT_ENTRY_WITH_RT_DST
+/* On MacOSX and FreeBSD struct rtentry is not directly available.
+ * On FreeBSD one could #define _WANT_RTENTRY but the struct does not
+ * contain rt_dst for instance. The entries for mask and destination
+ * are maintained in a separate radix_tree structure by the routing
+ * table instance. We can not simply copy rtentry structures.
+ */
 
 /* This structure gets passed by the SIOCADDRT and SIOCDELRT calls. */
 struct rtentry {

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -18,11 +18,21 @@
 #ifndef _OPENFORTIVPN_IPV4_H
 #define _OPENFORTIVPN_IPV4_H
 
+#include <sys/types.h>
+#include <sys/socket.h>
+#ifdef HAVE_SYS_MUTEX_H
+/* Mac OSX and BSD wants this explicit include */
+#include <sys/mutex.h>
+#endif
 #include <netinet/in.h>
 #include <net/route.h>
+#include <net/if.h>
+#ifdef HAVE_NET_IF_IF_VAR_H
+/* on FreeBSD we need this additional header */
+#include <net/if_var.h>
+#endif
 
 #ifdef __APPLE__
-#include <sys/socket.h>
 
 /* This structure gets passed by the SIOCADDRT and SIOCDELRT calls. */
 struct rtentry {

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -34,17 +34,20 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
-#ifdef __APPLE__
+#ifdef __clang__
 /*
  * Get rid of OSX 10.7 and greater deprecation warnings
  * see for instance https://wiki.openssl.org/index.php/Hostname_validation
  * this pragma selectively suppresses this type of warnings in clang
  */
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#ifndef ERESTART
 /*
  * ERESTART is one of the recoverable errors which might be returned.
- * However, in OSX this constant is not defined in errno.h so we define
- * a dummy value here.
+ * However, in OSX and BSD this constant is not defined in errno.h
+ * so we define a dummy value here.
  */
 #define ERESTART -1
 #endif

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -41,10 +41,10 @@
 #include <sys/socket.h>
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
-#ifdef __APPLE__
-#include <util.h>
-#else
+#if HAVE_PTY_H
 #include <pty.h>
+#elif HAVE_UTIL_H
+#include <util.h>
 #endif
 #include <signal.h>
 #include <sys/wait.h>

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -46,7 +46,12 @@
 #elif HAVE_UTIL_H
 #include <util.h>
 #endif
+#if HAVE_LIBUTIL
+#include <libutil.h>
+#endif
+#if HAVE_TERMIOS_H
 #include <termios.h>
+#endif
 #include <signal.h>
 #include <sys/wait.h>
 #include <assert.h>

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -46,6 +46,7 @@
 #elif HAVE_UTIL_H
 #include <util.h>
 #endif
+#include <termios.h>
 #include <signal.h>
 #include <sys/wait.h>
 #include <assert.h>
@@ -98,7 +99,7 @@ static int pppd_run(struct tunnel *tunnel)
 {
 	pid_t pid;
 	int amaster;
-#ifndef __APPLE__
+#ifdef HAVE_STRUCT_TERMIOS
 	struct termios termp = {
 		.c_cflag = B9600,
 		.c_cc[VTIME] = 0,
@@ -113,10 +114,10 @@ static int pppd_run(struct tunnel *tunnel)
 		return 1;
 	}
 
-#ifdef __APPLE__
-	pid = forkpty(&amaster, NULL, NULL, NULL);
-#else
+#ifdef HAVE_STRUCT_TERMIOS
 	pid = forkpty(&amaster, NULL, &termp, NULL);
+#else
+	pid = forkpty(&amaster, NULL, NULL, NULL);
 #endif
 
 	if (pid == -1) {

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -36,7 +36,7 @@
 #include <openssl/ssl.h>
 #include <sys/types.h>
 
-#ifdef __APPLE__
+#ifdef __clang__
 /*
  * Get rid of OSX 10.7 and greater deprecation warnings
  * see for instance https://wiki.openssl.org/index.php/Hostname_validation


### PR DESCRIPTION
I have started this work some time ago. At the current stage I have managed to configure, compile and run _openfortivpn_ on FreeBSD 11.
The last remaining issue is that FreeBSD doesn't have `pppd` anymore and uses a user-space tool called `ppp`. It doesn't take many options from the command line but rather from STDIN or from a config file. To my understanding of the [man page](https://www.freebsd.org/cgi/man.cgi?query=ppp&sektion=8) it should be possible to put all necessary parameters into `/etc/ppp/ppp.conf` and _openfortivpn_ should work with this. If this works, the only missing bit is to provide a working sample configuration and perhaps an update of the man page.
Many command line options of _openfortivpn_ concerning how `pppd` is called are currently not supported on BSD. At a later stage one can modify the way `ppp` is called and pipe setup commands into the client before sending it to the background. I just haven't figured out to do this correctly in combination with `forkpty`, but we can keep this as a separate task, once `ppp` has successfully opened a connection by feeding it with appropriate parameters from a config file.